### PR TITLE
fix: classname for headerbar button

### DIFF
--- a/src/components/header-bar/command-palette/command-palette.jsx
+++ b/src/components/header-bar/command-palette/command-palette.jsx
@@ -177,7 +177,7 @@ const CommandPalette = ({ apps, commands, shortcuts }) => {
                 button:active {
                     background: #104067;
                 }
-                .headerbar {
+                .headerbar-apps-menu {
                     position: relative;
                     height: 100%;
                 }


### PR DESCRIPTION
Probably got reverted during the recent style update