### PR TITLE
fix(plugin-loader): handle faulty app urls

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-03-05T12:25:47.036Z\n"
-"PO-Revision-Date: 2025-03-05T12:25:47.036Z\n"
+"POT-Creation-Date: 2025-03-05T22:04:46.885Z\n"
+"PO-Revision-Date: 2025-03-05T22:04:46.885Z\n"
 
 msgid "Save your data"
 msgstr "Save your data"
@@ -35,6 +35,12 @@ msgstr "Reload"
 
 msgid "Unable to load the requested page from DHIS2. Returned to previous page."
 msgstr "Unable to load the requested page from DHIS2. Returned to previous page."
+
+msgid "Unable to find an app for this URL. Redirecting to home page."
+msgstr "Unable to find an app for this URL. Redirecting to home page."
+
+msgid "Something went wrong"
+msgstr "Something went wrong"
 
 msgid "Browse apps"
 msgstr "Browse apps"

--- a/src/components/PluginLoader.jsx
+++ b/src/components/PluginLoader.jsx
@@ -144,7 +144,7 @@ export const PluginLoader = ({ appsInfoQuery }) => {
 
             if (!newPluginEntrypoint) {
                 console.error(
-                    `The app slug ${params.appName} did not match any app. Redirecting to the home page in 5 seconds`
+                    `The app slug "${params.appName}" did not match any app. Redirecting to the home page in 5 seconds`
                 )
                 setError(
                     i18n.t(

--- a/src/components/PluginLoader.jsx
+++ b/src/components/PluginLoader.jsx
@@ -78,6 +78,8 @@ const listenForCommandPaletteToggle = (event) => {
 }
 
 /**
+ * ⭐️ This is what redirects back to the regular login app when logged out ⭐️
+ *
  * If the iframe loads a page that is different from the pluginSource given to
  * it, navigate the whole page there. This should handle two cases:
  * 1. The navigation is outside the DHIS2 instance: we want to leave the shell

--- a/src/components/PluginLoader.jsx
+++ b/src/components/PluginLoader.jsx
@@ -2,7 +2,7 @@ import { useAlert, useConfig } from '@dhis2/app-runtime'
 // eslint-disable-next-line import/no-unresolved
 import { Plugin } from '@dhis2/app-runtime/experimental'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation, useParams } from 'react-router'
 import { useClientOfflineInterface } from '../lib/clientPWAUpdateState.jsx'
 import i18n from '../locales/index.js'
@@ -106,8 +106,8 @@ export const PluginLoader = ({ appsInfoQuery }) => {
     const params = useParams()
     const location = useLocation()
     const { baseUrl } = useConfig()
-    const [pluginEntrypoint, setPluginEntrypoint] = React.useState()
-    const [rerenderKey, setRerenderKey] = React.useState(0)
+    const [pluginEntrypoint, setPluginEntrypoint] = useState()
+    const [rerenderKey, setRerenderKey] = useState(0)
     const { show: showNavigationWarning } = useAlert(
         i18n.t(
             'Unable to load the requested page from DHIS2. Returned to previous page.'
@@ -117,8 +117,8 @@ export const PluginLoader = ({ appsInfoQuery }) => {
     const initClientOfflineInterface = useClientOfflineInterface()
 
     // test prop messaging and updates
-    const [color, setColor] = React.useState('blue')
-    const toggleColor = React.useCallback(
+    const [color, setColor] = useState('blue')
+    const toggleColor = useCallback(
         () => setColor((prev) => (prev === 'blue' ? 'red' : 'blue')),
         []
     )
@@ -126,7 +126,7 @@ export const PluginLoader = ({ appsInfoQuery }) => {
     // todo: add query string to entrypoint (e.g. maps /dhis-web-maps/?currentAnalyticalObject=true)
     // Can use `urlObject.searchParams.append('redirect', 'false')`
     // (or is this a backend thing?)
-    React.useEffect(() => {
+    useEffect(() => {
         if (!appsInfoQuery.data) {
             return
         }
@@ -144,7 +144,7 @@ export const PluginLoader = ({ appsInfoQuery }) => {
         asyncWork()
     }, [params.appName, baseUrl, appsInfoQuery.data])
 
-    const pluginHref = React.useMemo(() => {
+    const pluginHref = useMemo(() => {
         // An absolute URL helps compare to the location inside the iframe:
         const pluginUrl = new URL(pluginEntrypoint, window.location)
         pluginUrl.hash = location.hash
@@ -153,7 +153,7 @@ export const PluginLoader = ({ appsInfoQuery }) => {
         return pluginUrl.href
     }, [pluginEntrypoint, location.hash, location.search])
 
-    const handleLoad = React.useCallback(
+    const handleLoad = useCallback(
         (event) => {
             // If we can't access the new page's Document, this is a cross-domain page.
             // Disallow that; return to previous plugin state.

--- a/src/components/PluginLoader.module.css
+++ b/src/components/PluginLoader.module.css
@@ -1,3 +1,7 @@
 .flexGrow {
     flex-grow: 1;
 }
+
+.marginBottom {
+    margin-block-end: 8px;
+}


### PR DESCRIPTION
Avoids infinite loops if an app is not found; in that case, it will show an error and redirect to the home page. Also avoids some other `undefined` values in the URLs


https://github.com/user-attachments/assets/069cb1bf-5f1e-476a-a990-1a4081d4c91b

