### PR TITLE
feat: pwa app index.html precache redirect workaround

### DIFF
--- a/src/components/header-bar/command-palette/hooks/use-actions.jsx
+++ b/src/components/header-bar/command-palette/hooks/use-actions.jsx
@@ -6,6 +6,7 @@ import {
     IconLogOut16,
     IconRedo16,
     IconTerminalWindow16,
+    IconWindow16,
 } from '@dhis2/ui-icons'
 import React, { useCallback, useMemo } from 'react'
 import i18n from '../../../../locales/index.js'
@@ -22,6 +23,7 @@ import {
     MIN_COMMANDS_NUM,
     MIN_SHORTCUTS_NUM,
 } from '../utils/constants.js'
+import { patchPwaApps } from '../utils/patch-pwa-apps.ts'
 
 export const useAvailableActions = ({ apps, shortcuts, commands }) => {
     const { baseUrl } = useConfig()
@@ -83,6 +85,14 @@ export const useAvailableActions = ({ apps, shortcuts, commands }) => {
                 icon: <IconLogOut16 color={colors.grey700} />,
                 dataTest: 'headerbar-logout',
                 action: () => logoutAction(logoutURL),
+            })
+            // Todo: remove
+            actionsArray.push({
+                type: ACTION,
+                name: 'Patch blank PWA apps — Bug bash',
+                icon: <IconWindow16 color={colors.grey700} />,
+                dataTest: 'headerbar-patch-pwa-apps-action',
+                action: patchPwaApps,
             })
         } else {
             actionsArray.push({

--- a/src/components/header-bar/command-palette/hooks/use-actions.jsx
+++ b/src/components/header-bar/command-palette/hooks/use-actions.jsx
@@ -6,7 +6,6 @@ import {
     IconLogOut16,
     IconRedo16,
     IconTerminalWindow16,
-    IconWindow16,
 } from '@dhis2/ui-icons'
 import React, { useCallback, useMemo } from 'react'
 import i18n from '../../../../locales/index.js'
@@ -23,7 +22,6 @@ import {
     MIN_COMMANDS_NUM,
     MIN_SHORTCUTS_NUM,
 } from '../utils/constants.js'
-import { patchPwaApps } from '../utils/patch-pwa-apps.ts'
 
 export const useAvailableActions = ({ apps, shortcuts, commands }) => {
     const { baseUrl } = useConfig()
@@ -85,14 +83,6 @@ export const useAvailableActions = ({ apps, shortcuts, commands }) => {
                 icon: <IconLogOut16 color={colors.grey700} />,
                 dataTest: 'headerbar-logout',
                 action: () => logoutAction(logoutURL),
-            })
-            // Todo: remove
-            actionsArray.push({
-                type: ACTION,
-                name: 'Patch blank PWA apps — Bug bash',
-                icon: <IconWindow16 color={colors.grey700} />,
-                dataTest: 'headerbar-patch-pwa-apps-action',
-                action: patchPwaApps,
             })
         } else {
             actionsArray.push({

--- a/src/components/header-bar/command-palette/utils/patch-pwa-apps.ts
+++ b/src/components/header-bar/command-palette/utils/patch-pwa-apps.ts
@@ -1,0 +1,50 @@
+const pwaApps = [
+    'dhis-web-dashboard',
+    'dhis-web-data-visualizer',
+    'dhis-web-maps',
+    'dhis-web-line-listing',
+    'api/apps/line-listing',
+    'dhis-web-aggregate-data-entry',
+]
+
+/**
+ * This is intended to fix a problem where the index.html file that servicer
+ * workers in PWA apps try to fetch actually gets redirected to the global shell
+ * index.html, which doesn't work with the rest of the app's assets. The result
+ * is a blank page after reloading the app
+ *
+ * The strategy is to fetch the _correct_ index.html file, using
+ * `?redirect=false` in the URL, then replacing the cache entry with the correct
+ * HTML file
+ */
+export const patchPwaApps = async () => {
+    // Get keys of app precaches
+    const allKeys = await caches.keys()
+    const precacheKeys = allKeys.filter((key) =>
+        pwaApps.some((app) => key.includes(app))
+    )
+
+    const results = await Promise.all(
+        precacheKeys.map(async (precacheKey) => {
+            const cache = await caches.open(precacheKey)
+            const appUrl = precacheKey.replace('workbox-precache-v2-', '')
+            const correctIndexHtml = await fetch(
+                `${appUrl}index.html?redirect=false`
+            )
+            const cacheKeys = await cache.keys()
+            const indexHtmlKey = cacheKeys.find((key) =>
+                key.url.includes('index.html')
+            )
+            if (indexHtmlKey) {
+                await cache.put(indexHtmlKey.url, correctIndexHtml)
+                console.log(`Patched ${appUrl}index.html`)
+                return true
+            }
+        })
+    )
+
+    if (results.some((r) => r)) {
+        console.log('Reloading to apply changes')
+        window.location.reload()
+    }
+}

--- a/src/components/header-bar/header-bar.jsx
+++ b/src/components/header-bar/header-bar.jsx
@@ -1,4 +1,5 @@
 import { useDataQuery, useConfig } from '@dhis2/app-runtime'
+import { IconWindow16 } from '@dhis2/ui'
 import { colors } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
@@ -6,7 +7,8 @@ import { useNavigate } from 'react-router'
 import i18n from '../../locales/index.js'
 import CommandPalette from './command-palette/command-palette.jsx'
 import { CommandPaletteContextProvider } from './command-palette/context/command-palette-context.jsx'
-import { APP } from './command-palette/utils/constants.js'
+import { APP, COMMAND } from './command-palette/utils/constants.js'
+import { patchPwaApps } from './command-palette/utils/patch-pwa-apps.ts'
 import { HeaderBarContextProvider } from './header-bar-context.jsx'
 import { joinPath } from './join-path.js'
 import { Logo } from './logo.jsx'
@@ -64,7 +66,18 @@ export const HeaderBar = ({
     }, [data, baseUrl, navigate])
 
     // fetch commands
-    const commands = []
+    const commands = [
+        // todo: remove this command
+        {
+            type: COMMAND,
+            name: 'Patch blank PWA apps — Bug bash',
+            icon: <IconWindow16 color={colors.grey700} />,
+            dataTest: 'headerbar-patch-pwa-apps-action',
+            description:
+                'Fixes apps that appear blank (potentially Dashboard, Data Visualizer, Maps, Line Listing, or Data Entry (beta))',
+            action: patchPwaApps,
+        },
+    ]
 
     // fetch shortcuts
     const shortcuts = []


### PR DESCRIPTION
In case we don't have the back-end fix for PWA app `index.html` precache redirects in, we can maybe use this front-end script to fix the apps -- I figured the command palette was a good place to put the script 😁 


https://github.com/user-attachments/assets/811be86a-a06c-424f-a055-65a53a96f9fc


