### PR TITLE
fix: hide global shell in headerbar title

### DIFF
--- a/src/components/ConnectedHeaderbar.jsx
+++ b/src/components/ConnectedHeaderbar.jsx
@@ -52,7 +52,7 @@ export function ConnectedHeaderBar({ appsInfoQuery }) {
     const appName = useMemo(() => {
         if (!params.appName || !appsInfoQuery.data) {
             // `undefined` defaults to app title in header bar component, i.e. "Global Shell"
-            return
+            return ' '
         }
         if (appsInfoQuery.data) {
             return getAppDisplayName(

--- a/src/components/header-bar/profile-menu/profile-menu.jsx
+++ b/src/components/header-bar/profile-menu/profile-menu.jsx
@@ -130,7 +130,7 @@ const ProfileContents = ({
                 div {
                     width: 100%;
                     padding: 0;
-                    background: white;
+                    background: ${colors.white};
                     box-shadow: ${elevations.e300};
                     border-radius: 3px;
                     border: 1px solid ${colors.grey300};


### PR DESCRIPTION
Minor fix to prevent flashing Global Shell in headerbar