### PR TITLE
feat: remove navigation key legend from small screens

### DIFF
--- a/src/components/header-bar/command-palette/sections/navigation-keys-legend.jsx
+++ b/src/components/header-bar/command-palette/sections/navigation-keys-legend.jsx
@@ -49,6 +49,11 @@ const NavigationKeysLegend = () => {
                     display: flex;
                     gap: ${spacers.dp24};
                 }
+                @media screen and (max-width: 480px) {
+                    div {
+                        display: none;
+                    }
+                }
             `}</style>
         </div>
     )


### PR DESCRIPTION
This PR only shows the navigation key legend on big screens, i.e with a `viewport width > 480px`.

#### Screenshots

1. Small
<img width="481" alt="mobile-home" src="https://github.com/user-attachments/assets/7d648f7c-2740-43ef-904d-e44d1e87ff33" />

<img width="477" alt="mobile -list" src="https://github.com/user-attachments/assets/ad8bbf6e-3d0f-489f-81d8-dba1b9a549b1" />

2. Large

<img width="1040" alt="large-home" src="https://github.com/user-attachments/assets/656f03bf-82a8-4dae-a09e-17beb12a9217" />

<img width="1051" alt="large-list" src="https://github.com/user-attachments/assets/29db524f-f8dc-4735-ae61-7b2f3b936d5c" />

