### PR TITLE
fix(routing): simplify routing; redirect to startModule at /apps/

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,11 @@
 import { useConfig, useDataQuery } from '@dhis2/app-runtime'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { BrowserRouter, Routes, Route, Link, Outlet } from 'react-router'
+import { BrowserRouter, Routes, Route, Outlet } from 'react-router'
 import styles from './App.module.css'
 import { ConnectedHeaderBar } from './components/ConnectedHeaderbar.jsx'
 import { PluginLoader } from './components/PluginLoader.jsx'
+import { RedirectHandler } from './components/RedirectHandler.tsx'
 import { ClientPWAProvider } from './lib/clientPWAUpdateState.jsx'
 
 const APPS_INFO_QUERY = {
@@ -19,13 +20,17 @@ const APPS_INFO_QUERY = {
     bundledApps: {
         resource: 'legacy::bundledApps',
     },
+    systemSettings: {
+        resource: 'systemSettings',
+    },
 }
 
 const Layout = ({ appsInfoQuery }) => {
     return (
         <div className={styles.container}>
             <ConnectedHeaderBar appsInfoQuery={appsInfoQuery} />
-            <Outlet />
+            {/* Skip the routes in dev; they don't make the same sense */}
+            {process.env.NODE_ENV !== 'development' ? <Outlet /> : null}
         </div>
     )
 }
@@ -40,7 +45,7 @@ const MyApp = () => {
         if (process.env.NODE_ENV === 'development') {
             return // undefined is okay
         }
-        return new URL(baseUrl).pathname
+        return new URL('apps', baseUrl).pathname
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
@@ -53,12 +58,15 @@ const MyApp = () => {
                 <Routes>
                     <Route element={<Layout appsInfoQuery={appsInfoQuery} />}>
                         <Route
-                            // todo: remove when done testing
-                            path="*"
-                            element={<Link to="/apps/localApp">Local App</Link>}
+                            path="/"
+                            element={
+                                <RedirectHandler
+                                    appsInfoQuery={appsInfoQuery}
+                                />
+                            }
                         />
                         <Route
-                            path="/apps/:appName"
+                            path="/:appName"
                             element={
                                 <PluginLoader appsInfoQuery={appsInfoQuery} />
                             }

--- a/src/components/RedirectHandler.tsx
+++ b/src/components/RedirectHandler.tsx
@@ -1,0 +1,65 @@
+import { Center, CircularLoader } from '@dhis2/ui'
+import React, { useEffect } from 'react'
+import { useNavigate } from 'react-router'
+
+type AppsInfoData = {
+    appMenu: Array<{
+        defaultAction: string
+        displayName: string
+        icon: string
+        name: string
+        namespace: string
+    }>
+    apps: Array<{
+        name: string
+        displayName: string
+        launchUrl: string
+        version: string
+        // ... and more
+    }>
+    bundledApps: Array<{
+        buildDate: string
+        name: string
+        source: string
+        sourceRef: string
+        sourceRepo: string
+        version: string
+        webName: string
+    }>
+    systemSettings: {
+        startModule: string
+        /* ...and more */
+    }
+}
+
+type AppsInfoQuery = {
+    data: AppsInfoData
+    loading: boolean
+    error: boolean
+}
+
+interface RedirectHandlerProps {
+    appsInfoQuery: AppsInfoQuery
+}
+
+export const RedirectHandler = ({ appsInfoQuery }: RedirectHandlerProps) => {
+    const navigate = useNavigate()
+
+    useEffect(() => {
+        if (!appsInfoQuery.data) {
+            return
+        }
+        const startModuleAppName =
+            appsInfoQuery.data.systemSettings.startModule.replace(
+                'dhis-web-',
+                ''
+            )
+        navigate(`/${startModuleAppName}`)
+    }, [appsInfoQuery.data, navigate])
+
+    return (
+        <Center>
+            <CircularLoader />
+        </Center>
+    )
+}

--- a/src/components/header-bar/command-palette/sections/app-item.jsx
+++ b/src/components/header-bar/command-palette/sections/app-item.jsx
@@ -8,7 +8,7 @@ import { linkClassName, linkStyles } from '../../react-router-link-styles.jsx'
 function AppItem({ name, displayName, img, highlighted, resetModal }) {
     return (
         <Link
-            to={`apps/${name.replace('dhis-web-', '')}`}
+            to={`/${name.replace('dhis-web-', '')}`}
             className={linkClassName}
             onClick={resetModal}
         >

--- a/src/components/header-bar/command-palette/sections/list-item.jsx
+++ b/src/components/header-bar/command-palette/sections/list-item.jsx
@@ -104,7 +104,7 @@ function ListItem({
         // Use react-router client-side routing to apps:
         return (
             <Link
-                to={`apps/${name?.replace('dhis-web-', '')}`}
+                to={`/${name?.replace('dhis-web-', '')}`}
                 className={linkClassName}
                 // ...and then close the palette
                 onClick={resetModal}

--- a/src/components/header-bar/header-bar.jsx
+++ b/src/components/header-bar/header-bar.jsx
@@ -60,7 +60,7 @@ export const HeaderBar = ({
             type: APP,
             icon: getPath(app.icon),
             action: () => {
-                navigate(`apps/${app.name.replace('dhis-web-', '')}`)
+                navigate(`/${app.name.replace('dhis-web-', '')}`)
             },
         }))
     }, [data, baseUrl, navigate])

--- a/src/components/header-bar/notifications.jsx
+++ b/src/components/header-bar/notifications.jsx
@@ -19,7 +19,7 @@ export const Notifications = ({
             {hasAuthority(userAuthorities, 'M_dhis-web-interpretation') && (
                 <NotificationIcon
                     count={interpretations}
-                    path={'/apps/interpretation'}
+                    path={'/interpretation'}
                     kind="message"
                     dataTestId="headerbar-interpretations"
                     title={i18n.t('Interpretations')}
@@ -31,7 +31,7 @@ export const Notifications = ({
                 <NotificationIcon
                     message="email"
                     count={messages}
-                    path={'/apps/messaging'}
+                    path={'/messaging'}
                     kind="interpretation"
                     dataTestId="headerbar-messages"
                     title={i18n.t('Messages')}

--- a/src/components/header-bar/profile-menu/profile-menu.jsx
+++ b/src/components/header-bar/profile-menu/profile-menu.jsx
@@ -54,7 +54,7 @@ const ProfileContents = ({
             />
             <ul data-test="headerbar-profile-menu">
                 <Link
-                    to={'/apps/user-profile#/settings'}
+                    to={'/user-profile#/settings'}
                     className={linkClassName}
                     onClick={hideProfileMenu}
                 >
@@ -66,7 +66,7 @@ const ProfileContents = ({
                     />
                 </Link>
                 <Link
-                    to={'/apps/user-profile#/account'}
+                    to={'/user-profile#/account'}
                     className={linkClassName}
                     onClick={hideProfileMenu}
                 >
@@ -78,7 +78,7 @@ const ProfileContents = ({
                     />
                 </Link>
                 <Link
-                    to={'/apps/user-profile#/profile'}
+                    to={'/user-profile#/profile'}
                     className={linkClassName}
                     onClick={hideProfileMenu}
                 >
@@ -102,7 +102,7 @@ const ProfileContents = ({
                     />
                 )}
                 <Link
-                    to={'/apps/user-profile#/aboutPage'}
+                    to={'/user-profile#/aboutPage'}
                     className={linkClassName}
                     onClick={hideProfileMenu}
                 >


### PR DESCRIPTION
[DHIS2-19158](https://dhis2.atlassian.net/browse/DHIS2-19158)

Also sets the `basename` for the router to be `/apps`, so that part of the path can be spared from client-side links

https://github.com/user-attachments/assets/9c775a54-e3d0-44f2-a449-a5b93e9aec77



[DHIS2-19158]: https://dhis2.atlassian.net/browse/DHIS2-19158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ