### PR TITLE
fix(router): correct basename resolution

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,7 +45,7 @@ const MyApp = () => {
         if (process.env.NODE_ENV === 'development') {
             return // undefined is okay
         }
-        return new URL('apps', baseUrl).pathname
+        return new URL(baseUrl + '/apps').pathname
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 


### PR DESCRIPTION
Because `baseUrl` doesn't end with a `/`, the `URL` constructor wasn't resolving to the right path, and nothing would load on an instance hosted at a subpath of the domain (😬) -- this format fixes that; tested on a PR deployment:

<img width="659" alt="Screenshot 2025-03-11 at 22 37 00" src="https://github.com/user-attachments/assets/7aafe3ed-b017-457e-9fd0-ac87a43da9dd" />
