### PR TITLE
fix: prevent current tab navigation on cmd/ctrl + click app

### DIFF
--- a/src/components/header-bar/command-palette/sections/list-item.jsx
+++ b/src/components/header-bar/command-palette/sections/list-item.jsx
@@ -19,13 +19,15 @@ function ListItem({
     dataTest = 'headerbar-list-item',
 }) {
     const showDescription = type === COMMAND
+    // todo: extend this to support shortcut links as well
     const isApp = type === APP
 
     const item = (
         <div
-            onClick={onClickHandler}
+            onClick={isApp ? undefined : onClickHandler}
             className={cx('item', { highlighted })}
             data-test={dataTest}
+            role={isApp ? undefined : 'button'}
             tabIndex={-1}
         >
             <div className="icon">

--- a/src/components/header-bar/command-palette/views/list-view.jsx
+++ b/src/components/header-bar/command-palette/views/list-view.jsx
@@ -29,7 +29,7 @@ const ListView = ({ grid, currentItem, resetModal }) => {
                         return (
                             <ListItem
                                 type={type}
-                                key={`app-${name}-${idx}`}
+                                key={`list-item-${idx}-${name}`}
                                 name={name}
                                 title={displayName || name}
                                 image={isImage ? icon : undefined}


### PR DESCRIPTION
What does this PR do?

- **Fixes** [DHIS2-19229](https://dhis2.atlassian.net/browse/DHIS2-19229)

- **Problem**: The app items are wrapped in a link and hence pressing `cmd/ctrl + clicking on an app` opens the app in a new tab (expected behavior). However, its onClickHandler also gets triggered causing it to open in the current tab as well. 
- **Solution**: This PR removes the action passed to the onClick handler for app items. 

- **Future?**: Remove action attribute for navigable items, like apps and shortcuts. 

[DHIS2-19229]: https://dhis2.atlassian.net/browse/DHIS2-19229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ