### PR TITLE
feat: move command palette to below the apps menu icon

### DIFF
--- a/src/components/header-bar/command-palette/sections/modal-container.jsx
+++ b/src/components/header-bar/command-palette/sections/modal-container.jsx
@@ -34,6 +34,11 @@ const ModalContainer = forwardRef(function ModalContainer(
             <dialog ref={ref}>{children}</dialog>
             <style jsx>{`
                 dialog {
+                    position: fixed;
+                    margin: 0;
+                    top: 40px;
+                    inset-inline-end: 40px;
+                    inset-inline-start: auto;
                     display: flex;
                     flex-direction: row;
                     border: none;
@@ -41,11 +46,9 @@ const ModalContainer = forwardRef(function ModalContainer(
                     padding: 1px;
                     width: 572px;
                     max-height: 544px;
-                    margin: 0 auto;
                     border-radius: 3px;
                     background: ${colors.white};
                     box-shadow: ${elevations.e100};
-                    margin-top: 92px;
                 }
             `}</style>
         </>


### PR DESCRIPTION
Implements [DHIS2-19213](https://dhis2.atlassian.net/browse/DHIS2-19213)

---
**Description**
This PR moves the command palette position to below the apps menu icon. For LTR, the command palette shows up on the top right, and for RTL, it shows up on the top left. 

---

**Screenshot**
<img width="905" alt="command-palette-ltr" src="https://github.com/user-attachments/assets/df6ac646-f0d8-477c-b934-b8f2c85bea56" />



[DHIS2-19213]: https://dhis2.atlassian.net/browse/DHIS2-19213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ