### PR TITLE
fix: fix infinite loop

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -1,6 +1,6 @@
 const config = {
     type: 'app',
-    name: 'global-app-shell', // This must be exact to be used as the global shell
+    name: 'global-shell', // This must be exact to be used as the global shell
     title: 'Global Shell',
 
     pwa: { enabled: true },

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-03-17T14:58:43.041Z\n"
-"PO-Revision-Date: 2025-03-17T14:58:43.042Z\n"
+"POT-Creation-Date: 2025-03-17T20:48:36.929Z\n"
+"PO-Revision-Date: 2025-03-17T20:48:36.929Z\n"
 
 msgid "Save your data"
 msgstr "Save your data"
@@ -33,11 +33,11 @@ msgstr "Cancel"
 msgid "Reload"
 msgstr "Reload"
 
-msgid "Unable to load the requested page from DHIS2. Returned to previous page."
-msgstr "Unable to load the requested page from DHIS2. Returned to previous page."
-
 msgid "Unable to find an app for this URL."
 msgstr "Unable to find an app for this URL."
+
+msgid "The requested page is not accessible from DHIS2."
+msgstr "The requested page is not accessible from DHIS2."
 
 msgid "Something went wrong"
 msgstr "Something went wrong"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-03-07T15:43:41.711Z\n"
-"PO-Revision-Date: 2025-03-07T15:43:41.712Z\n"
+"POT-Creation-Date: 2025-03-17T14:58:43.041Z\n"
+"PO-Revision-Date: 2025-03-17T14:58:43.042Z\n"
 
 msgid "Save your data"
 msgstr "Save your data"
@@ -36,11 +36,14 @@ msgstr "Reload"
 msgid "Unable to load the requested page from DHIS2. Returned to previous page."
 msgstr "Unable to load the requested page from DHIS2. Returned to previous page."
 
-msgid "Unable to find an app for this URL. Redirecting to home page."
-msgstr "Unable to find an app for this URL. Redirecting to home page."
+msgid "Unable to find an app for this URL."
+msgstr "Unable to find an app for this URL."
 
 msgid "Something went wrong"
 msgstr "Something went wrong"
+
+msgid "Return to home page"
+msgstr "Return to home page"
 
 msgid "Command palette"
 msgstr "Command palette"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { useConfig, useDataQuery } from '@dhis2/app-runtime'
+import { CssVariables } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { BrowserRouter, Routes, Route, Outlet } from 'react-router'
@@ -54,6 +55,7 @@ const MyApp = () => {
 
     return (
         <ClientPWAProvider>
+            <CssVariables colors />
             <BrowserRouter basename={basename}>
                 <Routes>
                     <Route element={<Layout appsInfoQuery={appsInfoQuery} />}>

--- a/src/components/PluginLoader.jsx
+++ b/src/components/PluginLoader.jsx
@@ -1,4 +1,3 @@
-import { useConfig } from '@dhis2/app-runtime'
 // eslint-disable-next-line import/no-unresolved
 import { Plugin } from '@dhis2/app-runtime/experimental'
 import { CircularLoader, CenteredContent, NoticeBox } from '@dhis2/ui'
@@ -33,29 +32,11 @@ const injectHeaderbarHidingStyles = (event) => {
 }
 
 // todo: this is kinda duplicated between here and the header bar
-const getAppDefaultAction = (appName, modules) => {
+const getPluginEntrypoint = (appName, modules) => {
     // If core apps get a different naming scheme, this needs revisiting
     return modules.find(
         (m) => m.name === appName || m.name === 'dhis-web-' + appName
     )?.defaultAction
-}
-
-const getPluginEntrypoint = (appName, modules /* baseUrl */) => {
-    const defaultAction = getAppDefaultAction(appName, modules)
-
-    // todo: app.html handling ----
-    // todo: this could be better if this can be detected from app entrypoints API
-    // const defaultAppUrl = new URL(defaultAction, baseUrl)
-    // const pluginifiedAppUrl = new URL('./app.html', defaultAppUrl)
-
-    // Start by trying to load pluginified app, `app.html`
-    // const pluginifiedAppResponse = await fetch(pluginifiedAppUrl)
-    // if (pluginifiedAppResponse.ok) {
-    //     return pluginifiedAppUrl.href
-    // }
-
-    // If pluginified app is not found, fall back to app root
-    return defaultAction
 }
 
 const watchForHashRouteChanges = (event) => {
@@ -112,16 +93,8 @@ const failedLoadErrorMessage =
 export const PluginLoader = ({ appsInfoQuery }) => {
     const params = useParams()
     const location = useLocation()
-    const { baseUrl } = useConfig()
     const initClientOfflineInterface = useClientOfflineInterface()
     const [error, setError] = useState(null)
-
-    // test prop messaging and updates
-    const [color, setColor] = useState('blue')
-    const toggleColor = useCallback(
-        () => setColor((prev) => (prev === 'blue' ? 'red' : 'blue')),
-        []
-    )
 
     const pluginHref = useMemo(() => {
         if (!appsInfoQuery.data) {
@@ -132,8 +105,7 @@ export const PluginLoader = ({ appsInfoQuery }) => {
         // for testing: params.appName === 'localApp' ? 'http://localhost:3001/app.html'
         const newPluginEntrypoint = getPluginEntrypoint(
             params.appName,
-            appsInfoQuery.data.appMenu.modules,
-            baseUrl
+            appsInfoQuery.data.appMenu.modules
         )
 
         if (!newPluginEntrypoint) {
@@ -151,13 +123,7 @@ export const PluginLoader = ({ appsInfoQuery }) => {
         pluginUrl.searchParams.append('redirect', 'false')
 
         return pluginUrl.href
-    }, [
-        location.hash,
-        location.search,
-        appsInfoQuery.data,
-        baseUrl,
-        params.appName,
-    ])
+    }, [location.hash, location.search, appsInfoQuery.data, params.appName])
 
     const handleLoad = useCallback(
         (event) => {
@@ -211,10 +177,6 @@ export const PluginLoader = ({ appsInfoQuery }) => {
             // pass URL hash down to the client app
             pluginSource={pluginHref}
             onLoad={handleLoad}
-            // Other props
-            // (for testing:)
-            color={color}
-            toggleColor={toggleColor}
         />
     )
 }

--- a/src/components/PluginLoader.jsx
+++ b/src/components/PluginLoader.jsx
@@ -4,7 +4,7 @@ import { Plugin } from '@dhis2/app-runtime/experimental'
 import { CircularLoader, CenteredContent, NoticeBox } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useCallback, useMemo, useState } from 'react'
-import { useLocation, useParams } from 'react-router'
+import { Link, useLocation, useParams } from 'react-router'
 import { useClientOfflineInterface } from '../lib/clientPWAUpdateState.jsx'
 import i18n from '../locales/index.js'
 import styles from './PluginLoader.module.css'
@@ -137,16 +137,9 @@ export const PluginLoader = ({ appsInfoQuery }) => {
 
         if (!newPluginEntrypoint) {
             console.error(
-                `The app slug "${params.appName}" did not match any app. Redirecting to the home page in 5 seconds`
+                `The app slug "${params.appName}" did not match any app.`
             )
-            setError(
-                i18n.t(
-                    'Unable to find an app for this URL. Redirecting to home page.'
-                )
-            )
-            setTimeout(() => {
-                window.location.href = baseUrl
-            }, 5000)
+            setError(i18n.t('Unable to find an app for this URL.'))
             return
         }
 
@@ -200,7 +193,9 @@ export const PluginLoader = ({ appsInfoQuery }) => {
             <CenteredContent>
                 <NoticeBox title={i18n.t('Something went wrong')} error>
                     <div className={styles.marginBottom}>{error}</div>
-                    <CircularLoader small />
+                    <Link to={'/'} className={styles.link}>
+                        {i18n.t('Return to home page')}
+                    </Link>
                 </NoticeBox>
             </CenteredContent>
         )

--- a/src/components/PluginLoader.module.css
+++ b/src/components/PluginLoader.module.css
@@ -5,3 +5,7 @@
 .marginBottom {
     margin-block-end: 8px;
 }
+
+.link {
+    color: var(--colors-grey800)
+}

--- a/src/components/header-bar/logo.jsx
+++ b/src/components/header-bar/logo.jsx
@@ -7,7 +7,7 @@ export const Logo = () => {
 
     return (
         <div data-test="headerbar-logo">
-            <a href={baseUrl}>
+            <a href={baseUrl + '/apps/'}>
                 <LogoImage />
             </a>
 


### PR DESCRIPTION
[DHIS2-19230](https://dhis2.atlassian.net/browse/DHIS2-19230)

Fixes a couple UX things:
1. Waits for the user to redirect back to the home page if an app is not found for a given `app-name`
2. Doesn't automatically redirect to the previous page if the global shell tries to load a broken/nonexistent page, instead showing a similar Info Box with a link back to the home page. This can be tested by either:
    1. Deleting the workbox precache for a PWA app, then visiting the app (without unregistering the service worker -- unregistering the service worker will then fix this case)
    2. Visiting an app, then turning of the server, then trying to visit another app

Other:
1. Uses `global-shell` as the app name
3. Header bar logo routes to `/apps/` to support offline

Before:

https://github.com/user-attachments/assets/fb338186-dfca-4edf-840f-884c9dedae05


After:

https://github.com/user-attachments/assets/0df6270f-886f-4c21-92f9-a4ece24e5344




[DHIS2-19230]: https://dhis2.atlassian.net/browse/DHIS2-19230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ