### PR TITLE
fix: revert to centered position on mobile form-factors

### DIFF
--- a/src/components/header-bar/command-palette/sections/modal-container.jsx
+++ b/src/components/header-bar/command-palette/sections/modal-container.jsx
@@ -35,10 +35,10 @@ const ModalContainer = forwardRef(function ModalContainer(
             <style jsx>{`
                 dialog {
                     position: fixed;
-                    margin: 0;
+                    margin: 0 auto;
                     top: 40px;
-                    inset-inline-end: 40px;
-                    inset-inline-start: auto;
+                    inset-inline-end: 0;
+                    inset-inline-start: 0;
                     display: flex;
                     flex-direction: row;
                     border: none;
@@ -49,6 +49,13 @@ const ModalContainer = forwardRef(function ModalContainer(
                     border-radius: 3px;
                     background: ${colors.white};
                     box-shadow: ${elevations.e100};
+                }
+                @media screen and (min-width: 480px) {
+                    dialog {
+                        margin: 0;
+                        inset-inline-start: auto;
+                        inset-inline-end: 40px;
+                    }
                 }
             `}</style>
         </>


### PR DESCRIPTION
On small screens we shouldn't keep the 40px right margin, instead this reverts to a centered position.

![image](https://github.com/user-attachments/assets/1355ad91-1f50-433d-8abb-f21c045e44c4)
