### PR TITLE
fix: command palette styles

### DIFF
--- a/src/components/header-bar/command-palette/command-palette.jsx
+++ b/src/components/header-bar/command-palette/command-palette.jsx
@@ -211,7 +211,7 @@ const CommandPalette = ({ apps, commands, shortcuts }) => {
                 }
                 .headerbar-menu-content {
                     overflow-y: auto;
-                    max-height: calc(544px - 100px);
+                    max-height: calc(560px - 100px);
                 }
             `}</style>
         </div>

--- a/src/components/header-bar/command-palette/sections/modal-container.jsx
+++ b/src/components/header-bar/command-palette/sections/modal-container.jsx
@@ -48,7 +48,10 @@ const ModalContainer = forwardRef(function ModalContainer(
                     max-height: 560px;
                     border-radius: 3px;
                     background: ${colors.white};
-                    box-shadow: ${elevations.e100};
+                    box-shadow: ${elevations.e400};
+                }
+                dialog::backdrop {
+                    background-color: transparent;
                 }
             `}</style>
         </>

--- a/src/components/header-bar/command-palette/sections/modal-container.jsx
+++ b/src/components/header-bar/command-palette/sections/modal-container.jsx
@@ -45,7 +45,7 @@ const ModalContainer = forwardRef(function ModalContainer(
                     border-radius: 1px;
                     padding: 1px;
                     width: 572px;
-                    max-height: 544px;
+                    max-height: 560px;
                     border-radius: 3px;
                     background: ${colors.white};
                     box-shadow: ${elevations.e100};


### PR DESCRIPTION
This PR makes style adjustments to the command palette:

- [x] Adjust `dialog` backdrop to be `transparent` and increase `box-shadow`.
- [x] Increase max-height to show half of a overflowing item in `browse..` mode, to help the user understand there are more items overflowing.