### PR TITLE
fix: browser routing forward/back - don't mutate browser history

### DIFF
--- a/src/components/PluginLoader.jsx
+++ b/src/components/PluginLoader.jsx
@@ -46,7 +46,7 @@ const watchForHashRouteChanges = (event) => {
         const locationUrl = new URL(window.location)
         const targetHash = event.target.location.hash
 
-        // Only update hashes have changed
+        // Only update if hashes have changed
         if (locationUrl.hash !== targetHash) {
             // Update hash in the current location
             locationUrl.hash = targetHash
@@ -91,7 +91,7 @@ const handleExternalNavigation = (iframeLoadEvent, pluginHref) => {
         iframeUrl.origin !== currentUrl.origin ||
         iframeUrl.pathname !== currentUrl.pathname
     ) {
-        // Replace to not lose 'forward' history?
+        // Replace to not lose 'forward' history
         window.location.replace(iframeUrl)
         return true
     }

--- a/src/components/RedirectHandler.tsx
+++ b/src/components/RedirectHandler.tsx
@@ -54,7 +54,7 @@ export const RedirectHandler = ({ appsInfoQuery }: RedirectHandlerProps) => {
                 'dhis-web-',
                 ''
             )
-        navigate(`/${startModuleAppName}`)
+        navigate(`/${startModuleAppName}`, { replace: true })
     }, [appsInfoQuery.data, navigate])
 
     return (


### PR DESCRIPTION
[DHIS2-19181](https://dhis2.atlassian.net/browse/DHIS2-19181)

Improves routing by a lot -- there can still be a few rare quirks, for example a full page reload when going back to a different hash route in the same app, or a few hash routes being squashed into one after a reload, but the history across apps is now smooth and consistent

This contains a way to modify the location inside the iframe without modifying the iframe `src` (which leaks into top-level history), which should probably be moved to the `<Plugin>` component in `app-runtime`

https://github.com/user-attachments/assets/dd2aafb0-253d-451f-82eb-42987f2aab5f



[DHIS2-19181]: https://dhis2.atlassian.net/browse/DHIS2-19181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ