### PR TITLE
fix: track offline status even when iframes are focused

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "import-pwa": "yarn del-pwa && yarn del-nm-cache && yarn cp-pwa && yarn patch-package @dhis2/pwa",
         "import-headerbar": "yarn del-headerbar && yarn del-nm-cache && yarn cp-headerbar && yarn patch-package @dhis2-ui/header-bar",
         "import-plugin": "yarn del-plugin && yarn del-nm-cache && yarn cp-plugin && yarn patch-package @dhis2/app-service-plugin",
-        "import-offline": "yarn del-offline && yarn del-nm-cache && yarn cp-offline",
+        "import-offline": "yarn del-offline && yarn del-nm-cache && yarn cp-offline && yarn patch-package @dhis2/app-service-offline",
         "import-data": "yarn del-data && yarn del-nm-cache && yarn cp-data && yarn patch-package @dhis2/app-service-data"
     },
     "devDependencies": {

--- a/patches/@dhis2+app-service-offline+3.14.0.patch
+++ b/patches/@dhis2+app-service-offline+3.14.0.patch
@@ -1,0 +1,78 @@
+diff --git a/node_modules/@dhis2/app-service-offline/build/cjs/lib/dhis2-connection-status/dhis2-connection-status.js b/node_modules/@dhis2/app-service-offline/build/cjs/lib/dhis2-connection-status/dhis2-connection-status.js
+index afd68e7..5eed154 100644
+--- a/node_modules/@dhis2/app-service-offline/build/cjs/lib/dhis2-connection-status/dhis2-connection-status.js
++++ b/node_modules/@dhis2/app-service-offline/build/cjs/lib/dhis2-connection-status/dhis2-connection-status.js
+@@ -136,21 +136,28 @@ const Dhis2ConnectionStatusProvider = _ref => {
+       callback: pingAndHandleStatus
+     });
+     smartIntervalRef.current = smartInterval;
+-    const handleBlur = () => smartInterval.pause();
+-    const handleFocus = () => smartInterval.resume();
++
++    // Use visibility change instead of focus/blur to continue while focus
++    // might be in iframes
++    const handleVisibilityChange = () => {
++      if (document.visibilityState === 'hidden') {
++        smartInterval.pause();
++      } else {
++        // visibilityState === 'visible'
++        smartInterval.resume();
++      }
++    };
+     // Pinging when going offline should be low/no-cost in both online and
+     // local servers
+     const handleOffline = () => smartInterval.invokeCallbackImmediately();
+     // Pinging when going online has a cost but improves responsiveness of
+     // the connection status -- only do it once every 15 seconds at most
+     const handleOnline = (0, _lodash.throttle)(() => smartInterval.invokeCallbackImmediately(), 15000);
+-    window.addEventListener('blur', handleBlur);
+-    window.addEventListener('focus', handleFocus);
++    document.addEventListener('visibilitychange', handleVisibilityChange);
+     window.addEventListener('offline', handleOffline);
+     window.addEventListener('online', handleOnline);
+     return () => {
+-      window.removeEventListener('blur', handleBlur);
+-      window.removeEventListener('focus', handleFocus);
++      document.removeEventListener('visibilitychange', handleVisibilityChange);
+       window.removeEventListener('offline', handleOffline);
+       window.removeEventListener('online', handleOnline);
+ 
+diff --git a/node_modules/@dhis2/app-service-offline/build/es/lib/dhis2-connection-status/dhis2-connection-status.js b/node_modules/@dhis2/app-service-offline/build/es/lib/dhis2-connection-status/dhis2-connection-status.js
+index a7646bf..f7328b4 100644
+--- a/node_modules/@dhis2/app-service-offline/build/es/lib/dhis2-connection-status/dhis2-connection-status.js
++++ b/node_modules/@dhis2/app-service-offline/build/es/lib/dhis2-connection-status/dhis2-connection-status.js
+@@ -127,21 +127,28 @@ export const Dhis2ConnectionStatusProvider = _ref => {
+       callback: pingAndHandleStatus
+     });
+     smartIntervalRef.current = smartInterval;
+-    const handleBlur = () => smartInterval.pause();
+-    const handleFocus = () => smartInterval.resume();
++
++    // Use visibility change instead of focus/blur to continue while focus
++    // might be in iframes
++    const handleVisibilityChange = () => {
++      if (document.visibilityState === 'hidden') {
++        smartInterval.pause();
++      } else {
++        // visibilityState === 'visible'
++        smartInterval.resume();
++      }
++    };
+     // Pinging when going offline should be low/no-cost in both online and
+     // local servers
+     const handleOffline = () => smartInterval.invokeCallbackImmediately();
+     // Pinging when going online has a cost but improves responsiveness of
+     // the connection status -- only do it once every 15 seconds at most
+     const handleOnline = throttle(() => smartInterval.invokeCallbackImmediately(), 15000);
+-    window.addEventListener('blur', handleBlur);
+-    window.addEventListener('focus', handleFocus);
++    document.addEventListener('visibilitychange', handleVisibilityChange);
+     window.addEventListener('offline', handleOffline);
+     window.addEventListener('online', handleOnline);
+     return () => {
+-      window.removeEventListener('blur', handleBlur);
+-      window.removeEventListener('focus', handleFocus);
++      document.removeEventListener('visibilitychange', handleVisibilityChange);
+       window.removeEventListener('offline', handleOffline);
+       window.removeEventListener('online', handleOnline);
+ 


### PR DESCRIPTION
[DHIS2-19285](https://dhis2.atlassian.net/browse/DHIS2-19285)

Uses a patch of `app-runtime`, since the implementation there (https://github.com/dhis2/app-runtime/pull/1411) should be considered there before generalizing to all apps.

While an app is focused, visible, and inactive, this will result in some more pings being sent by the global shell than before. I don't think this is significant, because the number of pings is carefully managed to be low


https://github.com/user-attachments/assets/8f1bfb5f-8eea-41c7-ac49-06b2f8162fbb



[DHIS2-19285]: https://dhis2.atlassian.net/browse/DHIS2-19285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ