### PR TITLE
fix: test URL equivalency before replacing iframe location to avoid reloads

### DIFF
--- a/src/components/PluginLoader.jsx
+++ b/src/components/PluginLoader.jsx
@@ -218,12 +218,12 @@ export const PluginLoader = ({ appsInfoQuery }) => {
         if (!isBaseEquivalent(currentLocationUrl, newUrl)) {
             // If 'base' has changed, replace whole location
             iframeRef.current.contentWindow.location.replace(pluginHref)
-            return
         } else if (newUrl.hash !== currentLocationUrl.hash) {
             // If 'base' is functionally equivalent, update just hash,
             // if it has changed. Tested and preserves location state
             iframeRef.current.contentWindow.location.hash = newUrl.hash
         }
+        // Otherwise, URLs are identical; don't need to update
     }, [pluginHref])
 
     if (error) {


### PR DESCRIPTION
[DHIS2-19412](https://dhis2.atlassian.net/browse/DHIS2-19412)

If an app is using its app root `/` as base for hash routing, before this fix, new navigations in the app will trigger an update to `pluginHref`, which can then set the app's URL to `/index.html?redirect=false`, which can cause a whole-app reload, since it's a different path than before. This change checks for equivalent base paths, and if they are equivalent, only updates the iframe location's hash, if it has changed

Tested with a build of the new maintenance app from this PR: https://github.com/dhis2/maintenance-app-beta/pull/541


https://github.com/user-attachments/assets/876062b9-34dc-479f-b56f-5757f9582ad3

Also tested these scenarios:
- [x] Maintenance preview
- [x] Opening links in new tabs/copying and pasting
- [x] Deep links
    - [x] Agg DE
    - [x] Capture
- [x] Forward/back
- [x] Command palette
    - [x] App links
    - [x] Shortcuts
- [x] System settings
- [x] Analytics:
    - [x] Hash routing in ER, DV, Maps, Dashboard
    - [x] Opening event reports
    - [x] “Open as map”
    - [x] Manual URL changes
- [x] Other header-bar links (messaging, interpretations)
- [x] User profile menu



[DHIS2-19412]: https://dhis2.atlassian.net/browse/DHIS2-19412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ