### PR TITLE
feat: add <base target="_blank"> html element to client apps

### DIFF
--- a/src/components/PluginLoader.jsx
+++ b/src/components/PluginLoader.jsx
@@ -31,6 +31,26 @@ const injectHeaderbarHidingStyles = (event) => {
     }
 }
 
+/**
+ * Set <base target="_blank" in the app doc,
+ * so target="_blank" is the default for links, and they open in new tabs
+ */
+const injectHtmlBaseTag = (event) => {
+    try {
+        const iframe = event?.target || document.querySelector('iframe')
+        const doc = iframe.contentDocument
+        const baseElement = doc.createElement('base')
+        baseElement.target = '_blank'
+        doc.head.appendChild(baseElement)
+    } catch (err) {
+        console.error(
+            'Failed to inject <base> element in client app.' +
+                'This could be due to the client app being hosted on a different domain.',
+            err
+        )
+    }
+}
+
 // todo: this is kinda duplicated between here and the header bar
 const getPluginEntrypoint = (appName, modules) => {
     // If core apps get a different naming scheme, this needs revisiting
@@ -186,6 +206,7 @@ export const PluginLoader = ({ appsInfoQuery }) => {
                 return
             }
             injectHeaderbarHidingStyles(event)
+            injectHtmlBaseTag(event)
             watchForHashRouteChanges(event)
             initClientOfflineInterface({
                 clientWindow: event.target.contentWindow,


### PR DESCRIPTION
An alternate solution to [LIBS-765](https://dhis2.atlassian.net/browse/LIBS-765) and [DHIS2-19677](https://dhis2.atlassian.net/browse/DHIS2-19677) (more so the latter)

This is another feature that will be temporary before sandboxing, so it makes sense to do LIBS-765 too

https://github.com/user-attachments/assets/cc1fc4af-6e04-4081-9946-985577c94589



[LIBS-765]: https://dhis2.atlassian.net/browse/LIBS-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-19677]: https://dhis2.atlassian.net/browse/DHIS2-19677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ