### PR TITLE
fix: use app key instead of short_name to get version

### DIFF
--- a/src/components/ConnectedHeaderbar.jsx
+++ b/src/components/ConnectedHeaderbar.jsx
@@ -19,7 +19,7 @@ const getAppVersion = (appName, apps, bundledApps) => {
     const parsedAppName = appName.replace('dhis-web-', '')
     // First
     return (
-        apps.find((a) => a.short_name === parsedAppName)?.version ||
+        apps.find((a) => a.key === parsedAppName)?.version ||
         bundledApps.find((ba) => ba.name === parsedAppName)?.version
     )
 }


### PR DESCRIPTION
[DHIS2-19255](https://dhis2.atlassian.net/browse/DHIS2-19255)