### PR TITLE
fix: ensure that headerbar does not flicker when using custom color

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,6 +40,7 @@ const Layout = ({ appsInfoQuery }) => {
         sessionCookie?.serverTime &&
         systemInfo?.sessionTimeout
 
+    const appInfoQueryReady = Boolean(appsInfoQuery?.data)
     return (
         <div className={styles.container}>
             {supportsSessionHandler && (
@@ -47,7 +48,9 @@ const Layout = ({ appsInfoQuery }) => {
                     sessionTimeoutInSeconds={systemInfo?.sessionTimeout}
                 />
             )}
-            <ConnectedHeaderBar appsInfoQuery={appsInfoQuery} />
+            {appInfoQueryReady && (
+                <ConnectedHeaderBar appsInfoQuery={appsInfoQuery} />
+            )}
             {/* Skip the routes in dev; they don't make the same sense */}
             {process.env.NODE_ENV !== 'development' ? <Outlet /> : null}
         </div>

--- a/src/components/ConnectedHeaderbar.jsx
+++ b/src/components/ConnectedHeaderbar.jsx
@@ -97,7 +97,9 @@ export function ConnectedHeaderBar({ appsInfoQuery }) {
         ? selfPWAUpdateState
         : clientPWAUpdateState
 
-    const bgColor = appsInfoQuery?.data?.systemSettings.keyCustomColor
+    const bgColor =
+        appsInfoQuery?.data?.systemSettings.keyCustomColor || '#165c92'
+
     const color = useMemo(() => getContrastingColor(bgColor), [bgColor])
 
     const colorProviderProps = bgColor ? { bgColor, color } : {}

--- a/src/components/header-bar/header-bar.jsx
+++ b/src/components/header-bar/header-bar.jsx
@@ -196,7 +196,6 @@ export const HeaderBar = ({
                         flex-direction: row;
                         align-items: center;
                         justify-content: space-between;
-                        background-color: #165c92;
                         color: ${colors.white};
                         height: 40px;
                     }


### PR DESCRIPTION
this makes it wait for the settings to return before rendering the header

https://dhis2.atlassian.net/browse/DHIS2-21008