### PR TITLE
fix(DHIS2-21312): handle invalid app URLs in v43

### DIFF
--- a/src/components/ConnectedHeaderbar.jsx
+++ b/src/components/ConnectedHeaderbar.jsx
@@ -75,10 +75,15 @@ export function ConnectedHeaderBar({ appsInfoQuery }) {
         if (!params.appName || !appsInfoQuery.data) {
             return
         }
+
+        const bundledApps =
+            appsInfoQuery.data.bundledApps?.apps ??
+            appsInfoQuery.data.bundledApps
+
         return getAppVersion(
             params.appName,
             appsInfoQuery.data.apps,
-            appsInfoQuery.data.bundledApps
+            bundledApps
         )
     }, [appsInfoQuery.data, params.appName])
 

--- a/src/components/ConnectedHeaderbar.jsx
+++ b/src/components/ConnectedHeaderbar.jsx
@@ -76,6 +76,8 @@ export function ConnectedHeaderBar({ appsInfoQuery }) {
             return
         }
 
+        // In v43, the structure of the response changed from `[...apps]`
+        // to `{ buildDate, apps: [...apps] }`
         const bundledApps =
             appsInfoQuery.data.bundledApps?.apps ??
             appsInfoQuery.data.bundledApps


### PR DESCRIPTION


## with v43
<img width="3191" height="1013" alt="image" src="https://github.com/user-attachments/assets/56d64a33-2d5a-4faa-b648-eb0bd0c10db0" />

## with v42
https://dev.im.dhis2.org/test-global-shell/apps/xxx
<img width="3225" height="1777" alt="image" src="https://github.com/user-attachments/assets/73791169-0d6d-4c15-82d9-70e46f701ebb" />
